### PR TITLE
feat: logger middleware upset

### DIFF
--- a/snack/package-lock.json
+++ b/snack/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.2.6",
         "@nestjs/throttler": "^6.5.0",
+        "@prisma/adapter-mariadb": "^7.4.2",
         "@prisma/client": "^7.4.2",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
@@ -2807,6 +2808,16 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@prisma/adapter-mariadb": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-mariadb/-/adapter-mariadb-7.4.2.tgz",
+      "integrity": "sha512-s9iIan8UDce47Mdsqzm/JnFK/c2vmTXAtKYvBuE4zOockjxLZCB487AMPLx9CgUknqBsGlVqad7AY4QkznSYkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "7.4.2",
+        "mariadb": "3.4.5"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.4.2.tgz",
@@ -2854,7 +2865,6 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.4.2.tgz",
       "integrity": "sha512-aP7qzu+g/JnbF6U69LMwHoUkELiserKmWsE2shYuEpNUJ4GrtxBCvZwCyCBHFSH2kLTF2l1goBlBh4wuvRq62w==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/dev": {
@@ -2881,6 +2891,15 @@
         "std-env": "3.10.0",
         "valibot": "1.2.0",
         "zeptomatch": "2.1.0"
+      }
+    },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.4.2.tgz",
+      "integrity": "sha512-REdjFpT/ye9KdDs+CXAXPIbMQkVLhne9G5Pe97sNY4Ovx4r2DAbWM9hOFvvB1Oq8H8bOCdu0Ri3AoGALquQqVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.4.2"
       }
     },
     "node_modules/@prisma/engines": {
@@ -3223,6 +3242,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
@@ -5456,7 +5481,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
@@ -8384,6 +8408,55 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/mariadb": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/mariadb/-/mariadb-3.4.5.tgz",
+      "integrity": "sha512-gThTYkhIS5rRqkVr+Y0cIdzr+GRqJ9sA2Q34e0yzmyhMCwyApf3OKAC1jnF23aSlIOqJuyaUFUcj7O1qZslmmQ==",
+      "license": "LGPL-2.1-or-later",
+      "dependencies": {
+        "@types/geojson": "^7946.0.16",
+        "@types/node": "^24.0.13",
+        "denque": "^2.1.0",
+        "iconv-lite": "^0.6.3",
+        "lru-cache": "^10.4.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/mariadb/node_modules/@types/node": {
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/mariadb/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mariadb/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/mariadb/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/snack/package.json
+++ b/snack/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/throttler": "^6.5.0",
+    "@prisma/adapter-mariadb": "^7.4.2",
     "@prisma/client": "^7.4.2",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",

--- a/snack/src/app.module.ts
+++ b/snack/src/app.module.ts
@@ -1,9 +1,10 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PrismaModule } from './database/prisma.module';
 import { HealthModule } from './health/health.module';
+import { LoggerMiddleware } from './common/middleware/logger.middleware';
 
 @Module({
   imports: [
@@ -16,4 +17,8 @@ import { HealthModule } from './health/health.module';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(LoggerMiddleware).forRoutes('*');
+  }
+}

--- a/snack/src/common/middleware/logger.middleware.ts
+++ b/snack/src/common/middleware/logger.middleware.ts
@@ -1,0 +1,29 @@
+import {
+  Injectable,
+  NestMiddleware,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+  private readonly logger = new Logger('HTTP');
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const { method, originalUrl, ip } = req;
+    const userAgent = req.get('user-agent') ?? '';
+    const startTime = Date.now();
+
+    res.on('finish', () => {
+      const { statusCode } = res;
+      const contentLength = res.get('content-length') ?? 0;
+      const responseTime = Date.now() - startTime;
+
+      this.logger.log(
+        `${method} ${originalUrl} ${statusCode} ${contentLength}b - ${responseTime}ms - ${ip} - ${userAgent}`,
+      );
+    });
+
+    next();
+  }
+}

--- a/snack/src/database/prisma.service.ts
+++ b/snack/src/database/prisma.service.ts
@@ -1,19 +1,34 @@
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { PrismaClient } from '@prisma/client';
 import { PrismaMariaDb } from '@prisma/adapter-mariadb';
+
+function parseDatabaseUrl(url: string) {
+  const parsed = new URL(url);
+  return {
+    host: parsed.hostname,
+    port: parseInt(parsed.port, 10) || 3306,
+    user: parsed.username,
+    password: parsed.password,
+    database: parsed.pathname.slice(1),
+  };
+}
 
 @Injectable()
 export class PrismaService
   extends PrismaClient
   implements OnModuleInit, OnModuleDestroy
 {
-  constructor() {
+  constructor(private readonly configService: ConfigService) {
+    const databaseUrl = configService.getOrThrow<string>('DATABASE_URL');
+    const { host, port, user, password, database } = parseDatabaseUrl(databaseUrl);
+
     const adapter = new PrismaMariaDb({
-      host: 'localhost',
-      port: 3306,
-      user: 'admin',
-      password: 'admin',
-      database: 'snack',
+      host,
+      port,
+      user,
+      password,
+      database,
     });
 
     super({ adapter });


### PR DESCRIPTION
## Overview

<!-- 어떤 변경인지 간단히 설명 -->
1. database에서 구성시 .env에서 설정을 불러올 수 있도록 변경
2. log에 관한 middleware 추가

## Changes

- check only .env with starting db server
- add middleware according to log
-

## Why

<!-- 왜 이 변경이 필요한지 -->
1. 현 pr 기준 main에서는 db 서버 해킹이 쉬운 상태임. 이에 .env로 개인적이며 주요한 설정을 분리
2. log에 관한 middleware 추가는 추후 개발 단계에서 문제 인식에 도움을 줌.

## How to Test

<!-- 리뷰어가 테스트하는 방법 -->

1. .env 파일이 없는 상태에서 정상 작동하지 않아야 함.
2. .env 파일 생성 후에는 db 서버 연결이 정상 작동해야 함.
3. api 호출시 backend log에 정상 출력되어야 함.

## Screenshots (optional)

## Checklist

- [x] build 정상 동작
- [x] lint 통과
- [x] API 테스트 완료
- [x] breaking change 없음
