### PR TITLE
feat: email service fn, docs: swagger revise

### DIFF
--- a/snack/nest-cli.json
+++ b/snack/nest-cli.json
@@ -3,6 +3,15 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "plugins": [
+      {
+        "name": "@nestjs/swagger",
+        "options": {
+          "classValidatorShim": true,
+          "introspectComments": true
+        }
+      }
+    ]
   }
 }

--- a/snack/src/app.controller.ts
+++ b/snack/src/app.controller.ts
@@ -1,8 +1,11 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('App')
 @Controller()
 export class AppController {
   @Get()
+  @ApiOperation({ summary: '헬스체크' })
   root() {
     return {
       message: 'SNACK backend is running!!',

--- a/snack/src/auth/auth.controller.ts
+++ b/snack/src/auth/auth.controller.ts
@@ -10,7 +10,7 @@ import { ChangePasswordDto } from './dto/change-password.dto';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 
 @ApiTags('Auth')
-@Controller('api/auth')
+@Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
@@ -34,7 +34,7 @@ export class AuthController {
 
   @Post('logout')
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
+  @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '로그아웃' })
   logout(@CurrentUser() currentUser: CurrentUserPayload) {
     return this.authService.logout(currentUser);
@@ -42,7 +42,7 @@ export class AuthController {
 
   @Get('me')
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
+  @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '내 정보 조회' })
   getMe(@CurrentUser() currentUser: CurrentUserPayload) {
     return this.authService.getMe(currentUser);
@@ -50,7 +50,7 @@ export class AuthController {
 
   @Post('change-password')
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
+  @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '비밀번호 변경' })
   changePassword(
     @CurrentUser() user: CurrentUserPayload,

--- a/snack/src/auth/auth.service.ts
+++ b/snack/src/auth/auth.service.ts
@@ -259,6 +259,7 @@ export class AuthService {
           email: user.email,
           organizationId: primaryMembership.organizationId.toString(),
           role: primaryMembership.role,
+          sessionId: session.id.toString(),
         };
         await this.invitationService.accept(dto.invitationToken, currentUser);
         invitationAccepted = true;

--- a/snack/src/auth/dto/change-password.dto.ts
+++ b/snack/src/auth/dto/change-password.dto.ts
@@ -1,9 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsString, MinLength } from 'class-validator';
 
 export class ChangePasswordDto {
+  @ApiProperty({ description: '현재 비밀번호' })
   @IsString()
   currentPassword: string;
 
+  @ApiProperty({ description: '새 비밀번호', minLength: 8 })
   @IsString()
   @MinLength(8)
   newPassword: string;

--- a/snack/src/auth/dto/login.dto.ts
+++ b/snack/src/auth/dto/login.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsEmail,
   IsOptional,
@@ -7,15 +8,18 @@ import {
 } from 'class-validator';
 
 export class LoginDto {
+  @ApiProperty({ example: 'user@example.com' })
   @IsEmail()
   @MaxLength(320)
   email: string;
 
+  @ApiProperty({ example: 'password123', minLength: 8 })
   @IsString()
   @MinLength(8)
   @MaxLength(64)
   password: string;
 
+  @ApiPropertyOptional({ description: '초대 수락 시 로그인 후 자동 수락' })
   @IsOptional()
   @IsString()
   invitationToken?: string;

--- a/snack/src/auth/dto/signup.dto.ts
+++ b/snack/src/auth/dto/signup.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { OrgType } from '@prisma/client';
 import {
   IsEmail,
@@ -9,28 +10,34 @@ import {
 } from 'class-validator';
 
 export class SignUpDto {
+  @ApiProperty({ example: 'user@example.com' })
   @IsEmail()
   @MaxLength(320)
   email: string;
 
+  @ApiProperty({ example: 'password123', minLength: 8 })
   @IsString()
   @MinLength(8)
   @MaxLength(64)
   password: string;
 
+  @ApiProperty({ example: '홍길동' })
   @IsString()
   @MinLength(1)
   @MaxLength(100)
   displayName: string;
 
+  @ApiProperty({ example: 'Snack Team' })
   @IsString()
   @MinLength(1)
   @MaxLength(200)
   organizationName: string;
 
+  @ApiProperty({ enum: OrgType, example: OrgType.BUSINESS })
   @IsEnum(OrgType)
   orgType: OrgType;
 
+  @ApiPropertyOptional({ example: '1234567890' })
   @IsOptional()
   @IsString()
   @MaxLength(30)

--- a/snack/src/health/health.controller.ts
+++ b/snack/src/health/health.controller.ts
@@ -1,11 +1,14 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { PrismaService } from '../database/prisma.service';
 
+@ApiTags('Health')
 @Controller('health')
 export class HealthController {
   constructor(private readonly prisma: PrismaService) {}
 
   @Get()
+  @ApiOperation({ summary: '서비스 상태 확인' })
   getHealth() {
     return {
       status: 'ok',
@@ -15,6 +18,7 @@ export class HealthController {
   }
 
   @Get('db')
+  @ApiOperation({ summary: 'DB 연결 상태 확인' })
   async getDatabaseHealth() {
     await this.prisma.$queryRaw`SELECT 1`;
     return {

--- a/snack/src/invitation/dto/cancel-invitation.dto.ts
+++ b/snack/src/invitation/dto/cancel-invitation.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class CancelInvitationDto {
+  @ApiProperty({ description: '취소할 초대 대상 이메일' })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}

--- a/snack/src/invitation/dto/decline-invitation.dto.ts
+++ b/snack/src/invitation/dto/decline-invitation.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class DeclineInvitationDto {
+  @ApiProperty({ description: '초대 링크의 토큰' })
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+}

--- a/snack/src/invitation/invitation.controller.ts
+++ b/snack/src/invitation/invitation.controller.ts
@@ -7,16 +7,23 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { CurrentUserPayload } from '../auth/decorators/current-user.decorator';
 import { InvitationService } from './invitation.service';
 import { InviteDto } from './dto/invite.dto';
 import { AcceptInvitationDto } from './dto/accept-invitation.dto';
 import { InviteSignUpDto } from './dto/invite-signup.dto';
+import { DeclineInvitationDto } from './dto/decline-invitation.dto';
+import { CancelInvitationDto } from './dto/cancel-invitation.dto';
 
-@ApiTags('invitations')
+@ApiTags('Invitations')
 @Controller('invitations')
 export class InvitationController {
   constructor(private readonly invitationService: InvitationService) {}
@@ -27,6 +34,7 @@ export class InvitationController {
     description:
       '토큰 유효성 검사 및 이메일, 팀명, 회원가입 필요 여부 반환. needsSignUp=true면 회원가입, false면 로그인 유도',
   })
+  @ApiQuery({ name: 'token', required: true, description: '초대 링크의 토큰' })
   getInvitationInfo(@Query('token') token: string) {
     return this.invitationService.getInvitationInfo(token);
   }
@@ -43,7 +51,7 @@ export class InvitationController {
 
   @Post('organizations/:organizationId/invite')
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
+  @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '이메일로 조직 멤버 초대' })
   async invite(
     @Param('organizationId') organizationId: string,
@@ -59,12 +67,41 @@ export class InvitationController {
 
   @Post('accept')
   @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth()
+  @ApiBearerAuth('access-token')
   @ApiOperation({ summary: '초대 수락 (이메일 링크 클릭 후 로그인 필요)' })
   async accept(
     @Body() dto: AcceptInvitationDto,
     @CurrentUser() currentUser: CurrentUserPayload,
   ) {
     return this.invitationService.accept(dto.token, currentUser);
+  }
+
+  @Post('decline')
+  @ApiOperation({
+    summary: '초대 거절',
+    description:
+      '초대 대상이 수락을 거절. 로그인 불필요, 이메일 링크의 토큰만 필요',
+  })
+  async decline(@Body() dto: DeclineInvitationDto) {
+    return this.invitationService.decline(dto.token);
+  }
+
+  @Post('organizations/:organizationId/cancel')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: '초대 취소',
+    description: '초대자가 보낸 초대를 취소. 조직 관리자만 가능',
+  })
+  async cancel(
+    @Param('organizationId') organizationId: string,
+    @Body() dto: CancelInvitationDto,
+    @CurrentUser() currentUser: CurrentUserPayload,
+  ) {
+    return this.invitationService.cancel(
+      BigInt(organizationId),
+      dto.email,
+      currentUser,
+    );
   }
 }

--- a/snack/src/invitation/invitation.service.ts
+++ b/snack/src/invitation/invitation.service.ts
@@ -230,6 +230,103 @@ export class InvitationService {
     };
   }
 
+  /** 초대 거절 (초대 대상이 수락을 거절) - 토큰만 있으면 됨, 로그인 불필요 */
+  async decline(token: string) {
+    const redisKey = `${INVITATION_TOKEN_PREFIX}${token}`;
+    const redisData = await this.redis.get(redisKey);
+
+    if (!redisData) {
+      throw new AppException(
+        ErrorCode.TOKEN_EXPIRED,
+        '초대 링크가 만료되었거나 유효하지 않습니다.',
+      );
+    }
+
+    const { invitationId } = JSON.parse(redisData);
+
+    const invitation = await this.prisma.invitation.findUnique({
+      where: { id: BigInt(invitationId) },
+    });
+
+    if (
+      !invitation ||
+      invitation.status !== InvitationStatus.PENDING ||
+      invitation.expiresAt < new Date()
+    ) {
+      await this.redis.del(redisKey);
+      throw new AppException(
+        ErrorCode.TOKEN_EXPIRED,
+        '초대가 만료되었거나 이미 처리되었습니다.',
+      );
+    }
+
+    await this.prisma.invitation.update({
+      where: { id: BigInt(invitationId) },
+      data: {
+        status: InvitationStatus.REVOKED,
+        revokedAt: new Date(),
+      },
+    });
+
+    await this.redis.del(redisKey);
+
+    return {
+      message: '초대를 거절했습니다.',
+    };
+  }
+
+  /** 초대 취소 (초대자가 보낸 초대를 취소) - 조직 관리자만 가능 */
+  async cancel(organizationId: bigint, email: string, currentUser: CurrentUserPayload) {
+    const normalizedEmail = email.trim().toLowerCase();
+
+    const org = await this.prisma.organization.findUnique({
+      where: { id: organizationId },
+      include: { members: true },
+    });
+
+    if (!org) {
+      throw new AppException(ErrorCode.NOT_FOUND, '조직을 찾을 수 없습니다.');
+    }
+
+    const isAdmin = org.members.some(
+      (m) =>
+        m.userId.toString() === currentUser.sub &&
+        (m.role === OrgRole.ADMIN || m.role === OrgRole.SUPER_ADMIN),
+    );
+    if (!isAdmin) {
+      throw new AppException(ErrorCode.FORBIDDEN, '초대 취소 권한이 없습니다.');
+    }
+
+    const invitation = await this.prisma.invitation.findFirst({
+      where: {
+        organizationId,
+        email: normalizedEmail,
+        status: InvitationStatus.PENDING,
+        expiresAt: { gt: new Date() },
+      },
+    });
+
+    if (!invitation) {
+      throw new AppException(
+        ErrorCode.NOT_FOUND,
+        '취소할 대기 중인 초대가 없습니다.',
+      );
+    }
+
+    await this.prisma.invitation.update({
+      where: { id: invitation.id },
+      data: {
+        status: InvitationStatus.REVOKED,
+        revokedAt: new Date(),
+      },
+    });
+
+    return {
+      message: '초대를 취소했습니다.',
+      email: normalizedEmail,
+    };
+  }
+
   async getInvitationInfo(token: string) {
     const redisKey = `${INVITATION_TOKEN_PREFIX}${token}`;
     const redisData = await this.redis.get(redisKey);

--- a/snack/src/mail/mail.controller.ts
+++ b/snack/src/mail/mail.controller.ts
@@ -3,7 +3,7 @@ import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { MailService } from './mail.service';
 import { SendTestMailDto } from './dto/send-test-mail.dto';
 
-@ApiTags('mail')
+@ApiTags('Mail')
 @Controller('mail')
 export class MailController {
   constructor(private readonly mail: MailService) {}

--- a/snack/src/main.ts
+++ b/snack/src/main.ts
@@ -73,6 +73,17 @@ async function bootstrap() {
     .setTitle('SNACK API')
     .setDescription('SNACK backend API documentation')
     .setVersion('1.0.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'Authorization',
+        description: 'JWT Access Token 입력',
+        in: 'header',
+      },
+      'access-token',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, swaggerConfig);

--- a/snack/src/organizations/dto/update-organization-member-role.dto.ts
+++ b/snack/src/organizations/dto/update-organization-member-role.dto.ts
@@ -1,7 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { OrgRole } from '@prisma/client';
 import { IsEnum } from 'class-validator';
 
 export class UpdateOrganizationMemberRoleDto {
+  @ApiProperty({ enum: OrgRole, description: '변경할 역할' })
   @IsEnum(OrgRole)
   role: OrgRole;
 }

--- a/snack/src/organizations/organizations.controller.ts
+++ b/snack/src/organizations/organizations.controller.ts
@@ -17,9 +17,9 @@ import { UpdateOrganizationDto } from './dto/update-organization.dto';
 import { UpdateOrganizationMemberRoleDto } from './dto/update-organization-member-role.dto';
 
 @ApiTags('Organizations')
-@ApiBearerAuth()
+@ApiBearerAuth('access-token')
 @UseGuards(JwtAuthGuard)
-@Controller('api/organizations')
+@Controller('organizations')
 export class OrganizationsController {
   constructor(private readonly organizationsService: OrganizationsService) {}
 

--- a/snack/src/users/dto/update-my-profile.dto.ts
+++ b/snack/src/users/dto/update-my-profile.dto.ts
@@ -1,16 +1,20 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class UpdateMyProfileDto {
+  @ApiPropertyOptional({ example: '홍길동' })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   displayName?: string;
 
+  @ApiPropertyOptional({ example: '01012345678' })
   @IsOptional()
   @IsString()
   @MaxLength(30)
   phone?: string;
 
+  @ApiPropertyOptional({ description: '프로필 이미지 URL' })
   @IsOptional()
   @IsString()
   avatarUrl?: string;

--- a/snack/src/users/users.controller.ts
+++ b/snack/src/users/users.controller.ts
@@ -1,26 +1,26 @@
 import { Body, Controller, Get, Patch, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { CurrentUserPayload } from '../auth/decorators/current-user.decorator';
 import { UpdateMyProfileDto } from './dto/update-my-profile.dto';
 
-interface CurrentUserPayload {
-  sub: string;
-  email: string;
-  orgId?: string | null;
-}
-
+@ApiTags('Users')
+@ApiBearerAuth('access-token')
 @Controller('users')
 @UseGuards(JwtAuthGuard)
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get('me/profile')
+  @ApiOperation({ summary: '내 프로필 조회' })
   getMyProfile(@CurrentUser() user: CurrentUserPayload) {
     return this.usersService.getMyProfile(BigInt(user.sub));
   }
 
   @Patch('me/profile')
+  @ApiOperation({ summary: '내 프로필 수정' })
   updateMyProfile(
     @CurrentUser() user: CurrentUserPayload,
     @Body() dto: UpdateMyProfileDto,


### PR DESCRIPTION
## Overview

<!-- 어떤 변경인지 간단히 설명 -->

swagger 설정 오류 수정 및 mail service 취소 및 거절 추가

## Changes

- mail service 취소 및 거절 기능 api 추가
- swagger 설정 jwt 토큰 누락 및 body 누락, 이중 /api 수정
-

## Why

<!-- 왜 이 변경이 필요한지 -->

1. mail service에 기본적으로 취소 및 거절 기능이 있다. 이를 api로 구현
2. swagger 설정에 /api/api 의 형태로 user 및 org 파트에 들어가있었다. 이를 수정하였음
3. swagger에서 jwt bearer token을 입력할 수 있는 창이 누락되어 있음. 이를 수정

## How to Test

<!-- 리뷰어가 테스트하는 방법 -->

1.
2.
3.

## Screenshots (optional)

## Checklist

- [ ] build 정상 동작
- [ ] lint 통과
- [ ] API 테스트 완료
- [ ] breaking change 없음
