### PR TITLE
feat: 판매자 승인 / 주문 API

### DIFF
--- a/snack/src/app.module.ts
+++ b/snack/src/app.module.ts
@@ -14,6 +14,7 @@ import { UsersModule } from './users/users.module';
 import { CatalogModule } from './modules/catalog/catalog.module';
 import { CartModule } from './modules/cart/cart.module';
 import { PurchaseRequestModule } from './modules/purchase-request/purchase-request.module';
+import { SellerOrderModule } from './modules/seller-order/seller-order.module';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { PurchaseRequestModule } from './modules/purchase-request/purchase-reque
     CatalogModule,
     CartModule,
     PurchaseRequestModule,
+    SellerOrderModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/snack/src/modules/cart/controllers/cart.controller.ts
+++ b/snack/src/modules/cart/controllers/cart.controller.ts
@@ -9,8 +9,10 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../../common/guards/jwt-auth.guard';
 import { CartService } from '../services/cart.service';
 import { AddCartItemDto } from '../dto/add-cart-item.dto';
 import { UpdateCartItemQuantityDto } from '../dto/update-cart-item-quantity.dto';
@@ -19,6 +21,8 @@ import { OrganizationId } from '../../catalog/decorators/catalog-context.decorat
 import { UserId } from '../../catalog/decorators/catalog-context.decorator';
 
 @ApiTags('Cart')
+@ApiBearerAuth('access-token')
+@UseGuards(JwtAuthGuard)
 @Controller('cart')
 export class CartController {
   constructor(private readonly cartService: CartService) {}

--- a/snack/src/modules/catalog/controllers/product.controller.ts
+++ b/snack/src/modules/catalog/controllers/product.controller.ts
@@ -9,8 +9,10 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../../common/guards/jwt-auth.guard';
 import { ProductService } from '../services/product.service';
 import { CreateProductDto } from '../dto/create-product.dto';
 import { UpdateProductDto } from '../dto/update-product.dto';
@@ -20,6 +22,8 @@ import { OrganizationId } from '../decorators/catalog-context.decorator';
 import { UserId } from '../decorators/catalog-context.decorator';
 
 @ApiTags('Products')
+@ApiBearerAuth('access-token')
+@UseGuards(JwtAuthGuard)
 @Controller('products')
 export class ProductController {
   constructor(private readonly productService: ProductService) {}

--- a/snack/src/modules/catalog/decorators/catalog-context.decorator.ts
+++ b/snack/src/modules/catalog/decorators/catalog-context.decorator.ts
@@ -12,7 +12,13 @@ export const OrganizationId = createParamDecorator(
     const request = ctx.switchToHttp().getRequest();
     const raw = request.organizationId ?? request.user?.organizationId;
     const n = Number(raw);
-    if (raw === undefined || raw === null || raw === '' || Number.isNaN(n) || n < 1) {
+    if (
+      raw === undefined ||
+      raw === null ||
+      raw === '' ||
+      Number.isNaN(n) ||
+      n < 1
+    ) {
       throw new UnauthorizedException(
         '조직 컨텍스트가 없습니다. 로그인 및 조직 선택 후 다시 시도해 주세요.',
       );
@@ -29,7 +35,13 @@ export const UserId = createParamDecorator(
     const request = ctx.switchToHttp().getRequest();
     const raw = request.userId ?? request.user?.sub;
     const n = Number(raw);
-    if (raw === undefined || raw === null || raw === '' || Number.isNaN(n) || n < 1) {
+    if (
+      raw === undefined ||
+      raw === null ||
+      raw === '' ||
+      Number.isNaN(n) ||
+      n < 1
+    ) {
       throw new UnauthorizedException(
         '사용자 컨텍스트가 없습니다. 로그인 후 다시 시도해 주세요.',
       );

--- a/snack/src/modules/purchase-request/controllers/purchase-request.controller.ts
+++ b/snack/src/modules/purchase-request/controllers/purchase-request.controller.ts
@@ -7,8 +7,15 @@ import {
   ParseIntPipe,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../../common/guards/jwt-auth.guard';
 import { PurchaseRequestService } from '../services/purchase-request.service';
 import { CreatePurchaseRequestDto } from '../dto/create-purchase-request.dto';
 import { PurchaseRequestListQueryDto } from '../dto/purchase-request-list-query.dto';
@@ -17,6 +24,8 @@ import { OrganizationId } from '../../catalog/decorators/catalog-context.decorat
 import { UserId } from '../../catalog/decorators/catalog-context.decorator';
 
 @ApiTags('PurchaseRequest')
+@ApiBearerAuth('access-token')
+@UseGuards(JwtAuthGuard)
 @Controller('purchase-requests')
 export class PurchaseRequestController {
   constructor(

--- a/snack/src/modules/purchase-request/services/purchase-request.service.ts
+++ b/snack/src/modules/purchase-request/services/purchase-request.service.ts
@@ -5,6 +5,11 @@ import {
   purchase_orders_status,
   type PurchaseRequest,
 } from '@prisma/client';
+
+const PO_CANCELABLE_ON_REQUEST_CANCEL: purchase_orders_status[] = [
+  purchase_orders_status.PENDING_SELLER_APPROVAL,
+  purchase_orders_status.APPROVED,
+];
 import { PrismaService } from '../../../database/prisma.service';
 import { AppException } from '../../../common/exceptions/app.exception';
 import { ErrorCode } from '../../../common/enums/error-code.enum';
@@ -45,7 +50,9 @@ export class PurchaseRequestService {
     return typeof v === 'string' ? v : String(v);
   }
 
-  private toItemDto(row: RequestWithItems['purchase_request_items'][0]): PurchaseRequestItemResponseDto {
+  private toItemDto(
+    row: RequestWithItems['purchase_request_items'][0],
+  ): PurchaseRequestItemResponseDto {
     return {
       id: Number(row.id),
       sellerOrganizationId: Number(row.seller_organization_id),
@@ -295,17 +302,27 @@ export class PurchaseRequestService {
       );
     }
 
-    const updated = await this.prisma.purchaseRequest.update({
-      where: { id: existing.id },
-      data: {
-        status: PurchaseRequestStatus.CANCELED,
-        canceledAt: new Date(),
-      },
-      include: {
-        purchase_request_items: {
-          orderBy: { id: 'asc' },
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await tx.purchase_orders.updateMany({
+        where: {
+          purchase_request_id: existing.id,
+          status: { in: PO_CANCELABLE_ON_REQUEST_CANCEL },
         },
-      },
+        data: { status: purchase_orders_status.CANCELED },
+      });
+
+      return tx.purchaseRequest.update({
+        where: { id: existing.id },
+        data: {
+          status: PurchaseRequestStatus.CANCELED,
+          canceledAt: new Date(),
+        },
+        include: {
+          purchase_request_items: {
+            orderBy: { id: 'asc' },
+          },
+        },
+      });
     });
 
     return this.toDetail(updated as unknown as RequestWithItems);

--- a/snack/src/modules/seller-order/controllers/seller-order.controller.ts
+++ b/snack/src/modules/seller-order/controllers/seller-order.controller.ts
@@ -1,0 +1,143 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../../../auth/decorators/current-user.decorator';
+import type { JwtPayload } from '../../../common/types/jwt-payload.type';
+import { OrganizationId } from '../../catalog/decorators/catalog-context.decorator';
+import { SellerOrderService } from '../services/seller-order.service';
+import { SellerOrderListQueryDto } from '../dto/seller-order-list-query.dto';
+import { ApproveSellerOrderDto } from '../dto/approve-seller-order.dto';
+import { RejectSellerOrderDto } from '../dto/reject-seller-order.dto';
+import { RecordPurchaseDto } from '../dto/record-purchase.dto';
+import { UpdateShippingDto } from '../dto/update-shipping.dto';
+import { CancelSellerOrderDto } from '../dto/cancel-seller-order.dto';
+
+@ApiTags('SellerOrders')
+@ApiBearerAuth('access-token')
+@UseGuards(JwtAuthGuard)
+@Controller('seller/purchase-orders')
+export class SellerOrderController {
+  constructor(private readonly sellerOrderService: SellerOrderService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: '판매자 주문 목록',
+    description:
+      'JWT의 organizationId(판매자 조직) 기준. 조회는 조직 소속 멤버 모두 가능.',
+  })
+  @ApiResponse({ status: 200, description: '페이지네이션 목록' })
+  list(
+    @OrganizationId() sellerOrganizationId: number,
+    @Query() query: SellerOrderListQueryDto,
+  ) {
+    return this.sellerOrderService.findAll(sellerOrganizationId, query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '판매자 주문 상세' })
+  @ApiResponse({ status: 404, description: '없음' })
+  detail(
+    @OrganizationId() sellerOrganizationId: number,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
+    return this.sellerOrderService.findOne(sellerOrganizationId, id);
+  }
+
+  @Post(':id/approve')
+  @ApiOperation({
+    summary: '주문 승인',
+    description:
+      'PENDING_SELLER_APPROVAL → APPROVED. 구매 요청 라인으로 purchase_order_items 생성.',
+  })
+  approve(
+    @OrganizationId() sellerOrganizationId: number,
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: ApproveSellerOrderDto,
+  ) {
+    return this.sellerOrderService.approve(sellerOrganizationId, id, user, dto);
+  }
+
+  @Post(':id/reject')
+  @ApiOperation({
+    summary: '주문 거절',
+    description:
+      '동일 구매 요청의 다른 대기 주문은 CANCELED 처리. 구매 요청은 REJECTED로 갱신.',
+  })
+  reject(
+    @OrganizationId() sellerOrganizationId: number,
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: RejectSellerOrderDto,
+  ) {
+    return this.sellerOrderService.reject(sellerOrganizationId, id, user, dto);
+  }
+
+  @Post(':id/record-purchase')
+  @ApiOperation({
+    summary: '실제 구매 처리',
+    description:
+      'APPROVED → PURCHASED. 외부 쇼핑몰 주문번호·URL 기록. 플랫폼+외부주문번호 유일.',
+  })
+  recordPurchase(
+    @OrganizationId() sellerOrganizationId: number,
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: RecordPurchaseDto,
+  ) {
+    return this.sellerOrderService.recordPurchase(
+      sellerOrganizationId,
+      id,
+      user,
+      dto,
+    );
+  }
+
+  @Patch(':id/shipping')
+  @ApiOperation({
+    summary: '배송 상태 업데이트',
+    description: 'APPROVED 또는 PURCHASED 주문만.',
+  })
+  updateShipping(
+    @OrganizationId() sellerOrganizationId: number,
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: UpdateShippingDto,
+  ) {
+    return this.sellerOrderService.updateShipping(
+      sellerOrganizationId,
+      id,
+      user,
+      dto,
+    );
+  }
+
+  @Post(':id/cancel')
+  @ApiOperation({
+    summary: '판매자 주문 취소',
+    description: 'PENDING_SELLER_APPROVAL 또는 APPROVED만 취소 가능.',
+  })
+  cancel(
+    @OrganizationId() sellerOrganizationId: number,
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: CancelSellerOrderDto,
+  ) {
+    return this.sellerOrderService.cancel(sellerOrganizationId, id, user, dto);
+  }
+}

--- a/snack/src/modules/seller-order/dto/approve-seller-order.dto.ts
+++ b/snack/src/modules/seller-order/dto/approve-seller-order.dto.ts
@@ -1,0 +1,13 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumber, IsOptional, Min } from 'class-validator';
+
+export class ApproveSellerOrderDto {
+  @ApiPropertyOptional({
+    description: '배송비 (원). 승인 시 기록',
+    example: 3000,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  shippingFee?: number;
+}

--- a/snack/src/modules/seller-order/dto/cancel-seller-order.dto.ts
+++ b/snack/src/modules/seller-order/dto/cancel-seller-order.dto.ts
@@ -1,0 +1,10 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CancelSellerOrderDto {
+  @ApiPropertyOptional({ description: '취소 사유' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  message?: string;
+}

--- a/snack/src/modules/seller-order/dto/record-purchase.dto.ts
+++ b/snack/src/modules/seller-order/dto/record-purchase.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { purchase_orders_platform } from '@prisma/client';
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class RecordPurchaseDto {
+  @ApiProperty({ enum: purchase_orders_platform })
+  @IsEnum(purchase_orders_platform)
+  platform: purchase_orders_platform;
+
+  @ApiPropertyOptional({ description: '외부 쇼핑몰 주문번호' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  externalOrderNo?: string;
+
+  @ApiPropertyOptional({ description: '외부 주문 상세 URL' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  orderUrl?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  note?: string;
+}

--- a/snack/src/modules/seller-order/dto/reject-seller-order.dto.ts
+++ b/snack/src/modules/seller-order/dto/reject-seller-order.dto.ts
@@ -1,0 +1,10 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class RejectSellerOrderDto {
+  @ApiPropertyOptional({ description: '거절 사유' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  message?: string;
+}

--- a/snack/src/modules/seller-order/dto/seller-order-list-query.dto.ts
+++ b/snack/src/modules/seller-order/dto/seller-order-list-query.dto.ts
@@ -1,0 +1,26 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Max, Min } from 'class-validator';
+import { purchase_orders_status } from '@prisma/client';
+
+export class SellerOrderListQueryDto {
+  @ApiPropertyOptional({ minimum: 1, default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ minimum: 1, maximum: 100, default: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 10;
+
+  @ApiPropertyOptional({ enum: purchase_orders_status })
+  @IsOptional()
+  @IsEnum(purchase_orders_status)
+  status?: purchase_orders_status;
+}

--- a/snack/src/modules/seller-order/dto/update-shipping.dto.ts
+++ b/snack/src/modules/seller-order/dto/update-shipping.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsISO8601, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateShippingDto {
+  @ApiProperty({ example: 'SHIPPED', description: '배송 상태 라벨' })
+  @IsString()
+  @MaxLength(40)
+  shippingStatus: string;
+
+  @ApiPropertyOptional({ description: '배송 완료 시각 (ISO 8601)' })
+  @IsOptional()
+  @IsISO8601()
+  deliveredAt?: string;
+}

--- a/snack/src/modules/seller-order/seller-order.module.ts
+++ b/snack/src/modules/seller-order/seller-order.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SellerOrderController } from './controllers/seller-order.controller';
+import { SellerOrderService } from './services/seller-order.service';
+
+@Module({
+  controllers: [SellerOrderController],
+  providers: [SellerOrderService],
+  exports: [SellerOrderService],
+})
+export class SellerOrderModule {}

--- a/snack/src/modules/seller-order/services/seller-order.service.spec.ts
+++ b/snack/src/modules/seller-order/services/seller-order.service.spec.ts
@@ -1,0 +1,268 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  OrgRole,
+  Prisma,
+  PurchaseRequestStatus,
+  purchase_orders_status,
+} from '@prisma/client';
+import { SellerOrderService } from './seller-order.service';
+import { PrismaService } from '../../../database/prisma.service';
+import { AppException } from '../../../common/exceptions/app.exception';
+import { ErrorCode } from '../../../common/enums/error-code.enum';
+import type { JwtPayload } from '../../../common/types/jwt-payload.type';
+
+function adminPayload(): JwtPayload {
+  return {
+    sub: '99',
+    email: 'admin@seller.test',
+    organizationId: '10',
+    role: OrgRole.ADMIN,
+    sessionId: 'sess-1',
+  };
+}
+
+function memberPayload(): JwtPayload {
+  return {
+    sub: '100',
+    email: 'member@seller.test',
+    organizationId: '10',
+    role: OrgRole.MEMBER,
+    sessionId: 'sess-2',
+  };
+}
+
+describe('SellerOrderService', () => {
+  let service: SellerOrderService;
+  let prisma: jest.Mocked<
+    Pick<
+      PrismaService,
+      | 'purchase_orders'
+      | 'purchase_request_items'
+      | 'purchaseRequest'
+      | '$transaction'
+    >
+  >;
+
+  beforeEach(async () => {
+    prisma = {
+      purchase_orders: {
+        findMany: jest.fn(),
+        count: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+        updateMany: jest.fn(),
+      } as unknown as PrismaService['purchase_orders'],
+      purchase_request_items: {
+        findMany: jest.fn(),
+      } as unknown as PrismaService['purchase_request_items'],
+      purchaseRequest: {
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      } as unknown as PrismaService['purchaseRequest'],
+      $transaction: jest.fn(),
+    } as unknown as typeof prisma;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SellerOrderService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get(SellerOrderService);
+  });
+
+  describe('findAll', () => {
+    it('returns paginated summaries', async () => {
+      const row = {
+        id: 1n,
+        purchase_request_id: 5n,
+        buyer_organization_id: 2n,
+        status: purchase_orders_status.PENDING_SELLER_APPROVAL,
+        items_amount: new Prisma.Decimal('15000'),
+        created_at: new Date('2025-01-01T00:00:00.000Z'),
+        _count: { purchase_order_items: 0 },
+      };
+      (prisma.purchase_orders.findMany as jest.Mock).mockResolvedValue([row]);
+      (prisma.purchase_orders.count as jest.Mock).mockResolvedValue(1);
+
+      const result = await service.findAll(10, {
+        page: 1,
+        limit: 10,
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        id: 1,
+        purchaseRequestId: 5,
+        buyerOrganizationId: 2,
+        status: purchase_orders_status.PENDING_SELLER_APPROVAL,
+        itemsAmount: '15000',
+        lineCount: 0,
+      });
+      expect(prisma.purchase_orders.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { seller_organization_id: 10n },
+        }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('throws when order missing', async () => {
+      (prisma.purchase_orders.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.findOne(10, 999)).rejects.toThrow(AppException);
+      await expect(service.findOne(10, 999)).rejects.toMatchObject({
+        errorCode: ErrorCode.RESOURCE_NOT_FOUND,
+      });
+    });
+  });
+
+  describe('approve', () => {
+    it('forbids non-admin roles', async () => {
+      await expect(
+        service.approve(10, 1, memberPayload(), {}),
+      ).rejects.toMatchObject({ errorCode: ErrorCode.FORBIDDEN });
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('runs transaction: creates items, approves, rolls up purchase request', async () => {
+      const orderRow = {
+        id: 1n,
+        purchase_request_id: 100n,
+        buyer_organization_id: 2n,
+        seller_organization_id: 10n,
+        status: purchase_orders_status.PENDING_SELLER_APPROVAL,
+        platform: 'OTHER' as const,
+        external_order_no: null,
+        order_url: null,
+        items_amount: new Prisma.Decimal('2000'),
+        shipping_fee: new Prisma.Decimal('0'),
+        approved_at: null,
+        rejected_at: null,
+        ordered_at: null,
+        shipping_status: null,
+        delivered_at: null,
+        note: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+        purchased_by_user_id: null,
+        purchase_requests: { status: PurchaseRequestStatus.OPEN },
+        purchase_order_items: [],
+      };
+
+      const priLine = {
+        id: 50n,
+        purchase_request_id: 100n,
+        seller_organization_id: 10n,
+        product_id: 5n,
+        product_name_snapshot: 'Test Snack',
+        product_url_snapshot: null,
+        unit_price_snapshot: new Prisma.Decimal('1000'),
+        quantity: 2,
+        line_total: new Prisma.Decimal('2000'),
+        created_at: new Date(),
+      };
+
+      const buyerOrg = { id: 2n, name: 'Buyer Co' };
+
+      const orderItemRow = {
+        id: 77n,
+        purchase_order_id: 1n,
+        purchase_request_item_id: 50n,
+        product_id: 5n,
+        product_name_snapshot: 'Test Snack',
+        product_url_snapshot: null,
+        unit_price_snapshot: new Prisma.Decimal('1000'),
+        quantity: 2,
+        line_total: new Prisma.Decimal('2000'),
+        created_at: new Date('2025-01-02T00:00:00.000Z'),
+      };
+
+      const detailRow = {
+        ...orderRow,
+        status: purchase_orders_status.APPROVED,
+        approved_at: new Date('2025-01-02T00:00:00.000Z'),
+        purchase_order_items: [orderItemRow],
+        purchase_requests: { status: PurchaseRequestStatus.PARTIALLY_APPROVED },
+        organizations_purchase_orders_buyer_organization_idToorganizations:
+          buyerOrg,
+        purchase_order_decisions: [],
+      };
+
+      const tx = {
+        purchase_orders: {
+          findFirst: jest
+            .fn()
+            .mockResolvedValueOnce(orderRow)
+            .mockResolvedValueOnce(detailRow),
+          update: jest.fn().mockResolvedValue({}),
+          updateMany: jest.fn(),
+        },
+        purchase_request_items: {
+          findMany: jest.fn().mockResolvedValue([priLine]),
+        },
+        purchase_order_items: {
+          createMany: jest.fn().mockResolvedValue({ count: 1 }),
+        },
+        purchase_order_decisions: {
+          create: jest.fn().mockResolvedValue({}),
+        },
+        purchaseRequest: {
+          findUnique: jest.fn().mockResolvedValue({
+            id: 100n,
+            status: PurchaseRequestStatus.OPEN,
+            purchase_orders: [
+              { status: purchase_orders_status.PENDING_SELLER_APPROVAL },
+              { status: purchase_orders_status.APPROVED },
+            ],
+          }),
+          update: jest.fn().mockResolvedValue({}),
+        },
+      };
+
+      (prisma.$transaction as jest.Mock).mockImplementation(
+        async (fn: (t: typeof tx) => Promise<unknown>) => fn(tx),
+      );
+
+      const result = await service.approve(10, 1, adminPayload(), {
+        shippingFee: 500,
+      });
+
+      expect(tx.purchase_order_items.createMany).toHaveBeenCalled();
+      expect(tx.purchase_orders.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: purchase_orders_status.APPROVED,
+            shipping_fee: new Prisma.Decimal(500),
+          }),
+        }),
+      );
+      expect(tx.purchase_order_decisions.create).toHaveBeenCalled();
+      expect(tx.purchaseRequest.update).toHaveBeenCalled();
+      expect(result).toMatchObject({
+        id: 1,
+        status: purchase_orders_status.APPROVED,
+        buyerOrganizationName: 'Buyer Co',
+      });
+    });
+  });
+
+  describe('updateShipping', () => {
+    it('rejects when order not approved/purchased', async () => {
+      (prisma.purchase_orders.findFirst as jest.Mock).mockResolvedValue({
+        id: 1n,
+        status: purchase_orders_status.PENDING_SELLER_APPROVAL,
+        delivered_at: null,
+      });
+
+      await expect(
+        service.updateShipping(10, 1, adminPayload(), {
+          shippingStatus: 'SHIPPED',
+        }),
+      ).rejects.toMatchObject({ errorCode: ErrorCode.CONFLICT });
+    });
+  });
+});

--- a/snack/src/modules/seller-order/services/seller-order.service.ts
+++ b/snack/src/modules/seller-order/services/seller-order.service.ts
@@ -1,0 +1,619 @@
+import { Injectable } from '@nestjs/common';
+import {
+  OrgRole,
+  Prisma,
+  PurchaseRequestStatus,
+  purchase_order_decisions_decision,
+  purchase_orders_status,
+} from '@prisma/client';
+import { PrismaService } from '../../../database/prisma.service';
+import { AppException } from '../../../common/exceptions/app.exception';
+import { ErrorCode } from '../../../common/enums/error-code.enum';
+import type { JwtPayload } from '../../../common/types/jwt-payload.type';
+import { SellerOrderListQueryDto } from '../dto/seller-order-list-query.dto';
+import { ApproveSellerOrderDto } from '../dto/approve-seller-order.dto';
+import { RejectSellerOrderDto } from '../dto/reject-seller-order.dto';
+import { RecordPurchaseDto } from '../dto/record-purchase.dto';
+import { UpdateShippingDto } from '../dto/update-shipping.dto';
+import { CancelSellerOrderDto } from '../dto/cancel-seller-order.dto';
+
+const MUTABLE_PR_STATUSES: PurchaseRequestStatus[] = [
+  PurchaseRequestStatus.OPEN,
+  PurchaseRequestStatus.PARTIALLY_APPROVED,
+  PurchaseRequestStatus.READY_TO_PURCHASE,
+];
+
+@Injectable()
+export class SellerOrderService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private decStr(v: Prisma.Decimal): string {
+    return typeof v === 'string' ? v : String(v);
+  }
+
+  private assertSellerAdmin(role: OrgRole): void {
+    if (role !== OrgRole.ADMIN && role !== OrgRole.SUPER_ADMIN) {
+      throw new AppException(
+        ErrorCode.FORBIDDEN,
+        '판매자 주문 처리는 조직 관리자·최고 관리자만 가능합니다.',
+      );
+    }
+  }
+
+  private assertPurchaseRequestMutable(status: PurchaseRequestStatus): void {
+    if (!MUTABLE_PR_STATUSES.includes(status)) {
+      throw new AppException(
+        ErrorCode.CONFLICT,
+        '구매 요청이 더 이상 처리할 수 없는 상태입니다.',
+      );
+    }
+  }
+
+  /** 구매 요청에 속한 모든 판매자 주문 상태를 구매 요청 상태에 반영 */
+  private async rollupPurchaseRequestStatus(
+    tx: Prisma.TransactionClient,
+    purchaseRequestId: bigint,
+  ): Promise<void> {
+    const pr = await tx.purchaseRequest.findUnique({
+      where: { id: purchaseRequestId },
+      include: { purchase_orders: true },
+    });
+    if (!pr || pr.status === PurchaseRequestStatus.CANCELED) {
+      return;
+    }
+
+    const pos = pr.purchase_orders;
+    const S = purchase_orders_status;
+
+    if (pos.some((p) => p.status === S.REJECTED)) {
+      await tx.purchaseRequest.update({
+        where: { id: purchaseRequestId },
+        data: { status: PurchaseRequestStatus.REJECTED },
+      });
+      return;
+    }
+
+    if (pos.length === 0) {
+      return;
+    }
+
+    if (pos.every((p) => p.status === S.PURCHASED)) {
+      await tx.purchaseRequest.update({
+        where: { id: purchaseRequestId },
+        data: { status: PurchaseRequestStatus.PURCHASED },
+      });
+      return;
+    }
+
+    if (pos.every((p) => p.status === S.PENDING_SELLER_APPROVAL)) {
+      await tx.purchaseRequest.update({
+        where: { id: purchaseRequestId },
+        data: { status: PurchaseRequestStatus.OPEN },
+      });
+      return;
+    }
+
+    const hasPending = pos.some((p) => p.status === S.PENDING_SELLER_APPROVAL);
+    if (hasPending) {
+      await tx.purchaseRequest.update({
+        where: { id: purchaseRequestId },
+        data: { status: PurchaseRequestStatus.PARTIALLY_APPROVED },
+      });
+      return;
+    }
+
+    const terminalStatuses: purchase_orders_status[] = [
+      S.APPROVED,
+      S.PURCHASED,
+      S.CANCELED,
+    ];
+    const terminalMix = pos.every((p) => terminalStatuses.includes(p.status));
+    if (!terminalMix) {
+      await tx.purchaseRequest.update({
+        where: { id: purchaseRequestId },
+        data: { status: PurchaseRequestStatus.PARTIALLY_APPROVED },
+      });
+      return;
+    }
+
+    const hasApproved = pos.some((p) => p.status === S.APPROVED);
+    const hasPurchased = pos.some((p) => p.status === S.PURCHASED);
+
+    if (hasApproved && hasPurchased) {
+      await tx.purchaseRequest.update({
+        where: { id: purchaseRequestId },
+        data: { status: PurchaseRequestStatus.PARTIALLY_APPROVED },
+      });
+      return;
+    }
+
+    if (hasApproved && !hasPurchased) {
+      await tx.purchaseRequest.update({
+        where: { id: purchaseRequestId },
+        data: { status: PurchaseRequestStatus.READY_TO_PURCHASE },
+      });
+      return;
+    }
+
+    await tx.purchaseRequest.update({
+      where: { id: purchaseRequestId },
+      data: { status: PurchaseRequestStatus.PARTIALLY_APPROVED },
+    });
+  }
+
+  private toOrderSummary(
+    row: {
+      id: bigint;
+      purchase_request_id: bigint;
+      buyer_organization_id: bigint;
+      status: purchase_orders_status;
+      items_amount: Prisma.Decimal;
+      created_at: Date;
+    },
+    lineCount: number,
+  ) {
+    return {
+      id: Number(row.id),
+      purchaseRequestId: Number(row.purchase_request_id),
+      buyerOrganizationId: Number(row.buyer_organization_id),
+      status: row.status,
+      itemsAmount: this.decStr(row.items_amount),
+      lineCount,
+      createdAt: row.created_at.toISOString(),
+    };
+  }
+
+  async findAll(sellerOrganizationId: number, query: SellerOrderListQueryDto) {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 10;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.purchase_ordersWhereInput = {
+      seller_organization_id: BigInt(sellerOrganizationId),
+      ...(query.status != null && { status: query.status }),
+    };
+
+    const [rows, total] = await Promise.all([
+      this.prisma.purchase_orders.findMany({
+        where,
+        orderBy: { created_at: 'desc' },
+        skip,
+        take: limit,
+        include: {
+          _count: { select: { purchase_order_items: true } },
+        },
+      }),
+      this.prisma.purchase_orders.count({ where }),
+    ]);
+
+    return {
+      data: rows.map((r) =>
+        this.toOrderSummary(r, r._count.purchase_order_items),
+      ),
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit) || 1,
+    };
+  }
+
+  async findOne(
+    sellerOrganizationId: number,
+    orderId: number,
+    tx?: Prisma.TransactionClient,
+  ) {
+    const db = tx ?? this.prisma;
+    const row = await db.purchase_orders.findFirst({
+      where: {
+        id: BigInt(orderId),
+        seller_organization_id: BigInt(sellerOrganizationId),
+      },
+      include: {
+        purchase_order_items: { orderBy: { id: 'asc' } },
+        purchase_requests: true,
+        organizations_purchase_orders_buyer_organization_idToorganizations: {
+          select: { id: true, name: true },
+        },
+        purchase_order_decisions: { orderBy: { decided_at: 'desc' }, take: 5 },
+      },
+    });
+
+    if (!row) {
+      throw new AppException(
+        ErrorCode.RESOURCE_NOT_FOUND,
+        '주문을 찾을 수 없습니다.',
+      );
+    }
+
+    const requestLines = await db.purchase_request_items.findMany({
+      where: {
+        purchase_request_id: row.purchase_request_id,
+        seller_organization_id: BigInt(sellerOrganizationId),
+      },
+      orderBy: { id: 'asc' },
+    });
+
+    const buyer =
+      row.organizations_purchase_orders_buyer_organization_idToorganizations;
+
+    return {
+      id: Number(row.id),
+      purchaseRequestId: Number(row.purchase_request_id),
+      purchaseRequestStatus: row.purchase_requests.status,
+      buyerOrganizationId: Number(row.buyer_organization_id),
+      buyerOrganizationName: buyer.name,
+      sellerOrganizationId: Number(row.seller_organization_id),
+      status: row.status,
+      platform: row.platform,
+      externalOrderNo: row.external_order_no,
+      orderUrl: row.order_url,
+      itemsAmount: this.decStr(row.items_amount),
+      shippingFee: this.decStr(row.shipping_fee),
+      approvedAt: row.approved_at?.toISOString() ?? null,
+      rejectedAt: row.rejected_at?.toISOString() ?? null,
+      orderedAt: row.ordered_at?.toISOString() ?? null,
+      shippingStatus: row.shipping_status,
+      deliveredAt: row.delivered_at?.toISOString() ?? null,
+      note: row.note,
+      createdAt: row.created_at.toISOString(),
+      updatedAt: row.updated_at.toISOString(),
+      requestLines: requestLines.map((l) => ({
+        id: Number(l.id),
+        productId: l.product_id != null ? Number(l.product_id) : null,
+        productNameSnapshot: l.product_name_snapshot,
+        productUrlSnapshot: l.product_url_snapshot,
+        unitPriceSnapshot: this.decStr(l.unit_price_snapshot),
+        quantity: l.quantity,
+        lineTotal: this.decStr(l.line_total),
+      })),
+      orderLines: row.purchase_order_items.map((l) => ({
+        id: Number(l.id),
+        purchaseRequestItemId:
+          l.purchase_request_item_id != null
+            ? Number(l.purchase_request_item_id)
+            : null,
+        productId: l.product_id != null ? Number(l.product_id) : null,
+        productNameSnapshot: l.product_name_snapshot,
+        productUrlSnapshot: l.product_url_snapshot,
+        unitPriceSnapshot: this.decStr(l.unit_price_snapshot),
+        quantity: l.quantity,
+        lineTotal: this.decStr(l.line_total),
+        createdAt: l.created_at.toISOString(),
+      })),
+      recentDecisions: row.purchase_order_decisions.map((d) => ({
+        decision: d.decision,
+        message: d.decision_message,
+        decidedAt: d.decided_at.toISOString(),
+        decidedByUserId: Number(d.decided_by_user_id),
+      })),
+    };
+  }
+
+  async approve(
+    sellerOrganizationId: number,
+    orderId: number,
+    currentUser: JwtPayload,
+    dto: ApproveSellerOrderDto,
+  ) {
+    this.assertSellerAdmin(currentUser.role);
+
+    return this.prisma.$transaction(async (tx) => {
+      const row = await tx.purchase_orders.findFirst({
+        where: {
+          id: BigInt(orderId),
+          seller_organization_id: BigInt(sellerOrganizationId),
+        },
+        include: {
+          purchase_requests: true,
+          purchase_order_items: true,
+        },
+      });
+
+      if (!row) {
+        throw new AppException(
+          ErrorCode.RESOURCE_NOT_FOUND,
+          '주문을 찾을 수 없습니다.',
+        );
+      }
+
+      this.assertPurchaseRequestMutable(row.purchase_requests.status);
+
+      if (row.status !== purchase_orders_status.PENDING_SELLER_APPROVAL) {
+        throw new AppException(
+          ErrorCode.CONFLICT,
+          '승인할 수 있는 상태가 아닙니다.',
+        );
+      }
+
+      if (row.purchase_order_items.length > 0) {
+        throw new AppException(
+          ErrorCode.CONFLICT,
+          '이미 승인 처리된 주문입니다.',
+        );
+      }
+
+      const lines = await tx.purchase_request_items.findMany({
+        where: {
+          purchase_request_id: row.purchase_request_id,
+          seller_organization_id: BigInt(sellerOrganizationId),
+        },
+        orderBy: { id: 'asc' },
+      });
+
+      if (lines.length === 0) {
+        throw new AppException(
+          ErrorCode.BAD_REQUEST,
+          '연결된 구매 요청 라인이 없습니다.',
+        );
+      }
+
+      await tx.purchase_order_items.createMany({
+        data: lines.map((pri) => ({
+          purchase_order_id: row.id,
+          purchase_request_item_id: pri.id,
+          product_id: pri.product_id,
+          product_name_snapshot: pri.product_name_snapshot,
+          product_url_snapshot: pri.product_url_snapshot,
+          unit_price_snapshot: pri.unit_price_snapshot,
+          quantity: pri.quantity,
+          line_total: pri.line_total,
+        })),
+      });
+
+      const shippingFee =
+        dto.shippingFee != null
+          ? new Prisma.Decimal(dto.shippingFee)
+          : row.shipping_fee;
+
+      await tx.purchase_orders.update({
+        where: { id: row.id },
+        data: {
+          status: purchase_orders_status.APPROVED,
+          approved_at: new Date(),
+          shipping_fee: shippingFee,
+        },
+      });
+
+      await tx.purchase_order_decisions.create({
+        data: {
+          purchase_order_id: row.id,
+          decided_by_user_id: BigInt(currentUser.sub),
+          decision: purchase_order_decisions_decision.APPROVED,
+        },
+      });
+
+      await this.rollupPurchaseRequestStatus(tx, row.purchase_request_id);
+
+      return this.findOne(sellerOrganizationId, orderId, tx);
+    });
+  }
+
+  async reject(
+    sellerOrganizationId: number,
+    orderId: number,
+    currentUser: JwtPayload,
+    dto: RejectSellerOrderDto,
+  ) {
+    this.assertSellerAdmin(currentUser.role);
+
+    return this.prisma.$transaction(async (tx) => {
+      const row = await tx.purchase_orders.findFirst({
+        where: {
+          id: BigInt(orderId),
+          seller_organization_id: BigInt(sellerOrganizationId),
+        },
+        include: { purchase_requests: true },
+      });
+
+      if (!row) {
+        throw new AppException(
+          ErrorCode.RESOURCE_NOT_FOUND,
+          '주문을 찾을 수 없습니다.',
+        );
+      }
+
+      this.assertPurchaseRequestMutable(row.purchase_requests.status);
+
+      if (row.status !== purchase_orders_status.PENDING_SELLER_APPROVAL) {
+        throw new AppException(
+          ErrorCode.CONFLICT,
+          '거절할 수 있는 상태가 아닙니다.',
+        );
+      }
+
+      await tx.purchase_orders.updateMany({
+        where: {
+          purchase_request_id: row.purchase_request_id,
+          id: { not: row.id },
+          status: purchase_orders_status.PENDING_SELLER_APPROVAL,
+        },
+        data: { status: purchase_orders_status.CANCELED },
+      });
+
+      await tx.purchase_orders.update({
+        where: { id: row.id },
+        data: {
+          status: purchase_orders_status.REJECTED,
+          rejected_at: new Date(),
+        },
+      });
+
+      await tx.purchase_order_decisions.create({
+        data: {
+          purchase_order_id: row.id,
+          decided_by_user_id: BigInt(currentUser.sub),
+          decision: purchase_order_decisions_decision.REJECTED,
+          decision_message: dto.message?.trim() || null,
+        },
+      });
+
+      await this.rollupPurchaseRequestStatus(tx, row.purchase_request_id);
+
+      return this.findOne(sellerOrganizationId, orderId, tx);
+    });
+  }
+
+  async recordPurchase(
+    sellerOrganizationId: number,
+    orderId: number,
+    currentUser: JwtPayload,
+    dto: RecordPurchaseDto,
+  ) {
+    this.assertSellerAdmin(currentUser.role);
+
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const row = await tx.purchase_orders.findFirst({
+          where: {
+            id: BigInt(orderId),
+            seller_organization_id: BigInt(sellerOrganizationId),
+          },
+          include: { purchase_requests: true },
+        });
+
+        if (!row) {
+          throw new AppException(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            '주문을 찾을 수 없습니다.',
+          );
+        }
+
+        this.assertPurchaseRequestMutable(row.purchase_requests.status);
+
+        if (row.status !== purchase_orders_status.APPROVED) {
+          throw new AppException(
+            ErrorCode.CONFLICT,
+            '실제 구매 처리는 승인된 주문만 가능합니다.',
+          );
+        }
+
+        await tx.purchase_orders.update({
+          where: { id: row.id },
+          data: {
+            status: purchase_orders_status.PURCHASED,
+            platform: dto.platform,
+            external_order_no: dto.externalOrderNo?.trim() || null,
+            order_url: dto.orderUrl?.trim() || null,
+            note: dto.note?.trim() ?? row.note,
+            ordered_at: new Date(),
+            purchased_by_user_id: BigInt(currentUser.sub),
+          },
+        });
+
+        await this.rollupPurchaseRequestStatus(tx, row.purchase_request_id);
+
+        return this.findOne(sellerOrganizationId, orderId, tx);
+      });
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === 'P2002'
+      ) {
+        throw new AppException(
+          ErrorCode.ALREADY_EXISTS,
+          '동일 플랫폼·외부 주문번호가 이미 등록되어 있습니다.',
+        );
+      }
+      throw e;
+    }
+  }
+
+  async updateShipping(
+    sellerOrganizationId: number,
+    orderId: number,
+    currentUser: JwtPayload,
+    dto: UpdateShippingDto,
+  ) {
+    this.assertSellerAdmin(currentUser.role);
+
+    const row = await this.prisma.purchase_orders.findFirst({
+      where: {
+        id: BigInt(orderId),
+        seller_organization_id: BigInt(sellerOrganizationId),
+      },
+    });
+
+    if (!row) {
+      throw new AppException(
+        ErrorCode.RESOURCE_NOT_FOUND,
+        '주문을 찾을 수 없습니다.',
+      );
+    }
+
+    if (
+      row.status !== purchase_orders_status.APPROVED &&
+      row.status !== purchase_orders_status.PURCHASED
+    ) {
+      throw new AppException(
+        ErrorCode.CONFLICT,
+        '배송 상태는 승인 또는 구매 완료된 주문만 갱신할 수 있습니다.',
+      );
+    }
+
+    await this.prisma.purchase_orders.update({
+      where: { id: row.id },
+      data: {
+        shipping_status: dto.shippingStatus.trim(),
+        delivered_at: dto.deliveredAt
+          ? new Date(dto.deliveredAt)
+          : row.delivered_at,
+      },
+    });
+
+    return this.findOne(sellerOrganizationId, orderId);
+  }
+
+  async cancel(
+    sellerOrganizationId: number,
+    orderId: number,
+    currentUser: JwtPayload,
+    dto: CancelSellerOrderDto,
+  ) {
+    this.assertSellerAdmin(currentUser.role);
+
+    return this.prisma.$transaction(async (tx) => {
+      const row = await tx.purchase_orders.findFirst({
+        where: {
+          id: BigInt(orderId),
+          seller_organization_id: BigInt(sellerOrganizationId),
+        },
+        include: { purchase_requests: true },
+      });
+
+      if (!row) {
+        throw new AppException(
+          ErrorCode.RESOURCE_NOT_FOUND,
+          '주문을 찾을 수 없습니다.',
+        );
+      }
+
+      if (
+        row.status !== purchase_orders_status.PENDING_SELLER_APPROVAL &&
+        row.status !== purchase_orders_status.APPROVED
+      ) {
+        throw new AppException(
+          ErrorCode.CONFLICT,
+          '취소할 수 있는 상태가 아닙니다.',
+        );
+      }
+
+      this.assertPurchaseRequestMutable(row.purchase_requests.status);
+
+      const noteParts = [row.note, dto.message?.trim()]
+        .filter(Boolean)
+        .join('\n---\n');
+
+      await tx.purchase_orders.update({
+        where: { id: row.id },
+        data: {
+          status: purchase_orders_status.CANCELED,
+          note: noteParts || row.note,
+        },
+      });
+
+      await this.rollupPurchaseRequestStatus(tx, row.purchase_request_id);
+
+      return this.findOne(sellerOrganizationId, orderId, tx);
+    });
+  }
+}

--- a/snack/test/create-e2e-app.ts
+++ b/snack/test/create-e2e-app.ts
@@ -1,0 +1,33 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+import { ErrorInterceptor } from '../src/common/interceptors/error.interceptor';
+import { ResponseInterceptor } from '../src/common/interceptors/response.interceptor';
+
+/** main.ts와 동일한 글로벌 설정(프리픽스·파이프·응답 래핑)으로 부팅 */
+export async function createE2eApp(): Promise<INestApplication> {
+  const moduleFixture: TestingModule = await Test.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+
+  const app = moduleFixture.createNestApplication();
+  const nodeEnv = 'test';
+
+  app.setGlobalPrefix('api');
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  app.useGlobalFilters(new HttpExceptionFilter(nodeEnv));
+  app.useGlobalInterceptors(
+    new ErrorInterceptor(nodeEnv),
+    new ResponseInterceptor(),
+  );
+
+  await app.init();
+  return app;
+}

--- a/snack/test/flow.e2e-spec.ts
+++ b/snack/test/flow.e2e-spec.ts
@@ -1,0 +1,252 @@
+/**
+ * 전체 API 상호작용 검증 (구매자·판매자 조직, 상품·카트·구매요청·판매자 주문).
+ *
+ * 실행 전:
+ *   1) MySQL 기동 (예: docker compose up -d)
+ *   2) npx prisma migrate deploy
+ *   3) .env 또는 DATABASE_URL 등 JWT·DB 설정
+ *   4) Redis가 없으면 초대 API는 실패할 수 있으나 본 플로우는 Redis 미사용
+ *
+ * PowerShell:
+ *   $env:RUN_FLOW_E2E='1'
+ *   npm run test:e2e -- flow.e2e-spec.ts
+ */
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { createE2eApp } from './create-e2e-app';
+
+const runFlow = process.env.RUN_FLOW_E2E === '1';
+
+function okData<T>(res: request.Response, code?: number): T {
+  if (code != null) {
+    expect(res.status).toBe(code);
+  } else if (![200, 201].includes(res.status)) {
+    throw new Error(
+      `Expected HTTP 200/201, got ${res.status}: ${JSON.stringify(res.body)}`,
+    );
+  }
+  if (res.body?.success !== true) {
+    throw new Error(`Expected success: true: ${JSON.stringify(res.body)}`);
+  }
+  return res.body.data as T;
+}
+
+(runFlow ? describe : describe.skip)(
+  'API flow: buyer ↔ seller (e2e)',
+  () => {
+    let app: INestApplication;
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const buyerEmail = `buyer-${suffix}@flow.test`;
+    const sellerEmail = `seller-${suffix}@flow.test`;
+    const password = 'password12';
+
+    let buyerToken: string;
+    let sellerToken: string;
+    let buyerOrgId: string;
+    let sellerOrgId: string;
+    let buyerUserId: string;
+    let sellerUserId: string;
+    let categoryId: number;
+    let productId: number;
+    let purchaseRequestId: number;
+    let sellerOrderId: number;
+
+    beforeAll(async () => {
+      app = await createE2eApp();
+    }, 120000);
+
+    afterAll(async () => {
+      if (app) {
+        await app.close();
+      }
+    });
+
+    it('01 signup: buyer org + seller org', async () => {
+      const buyerRes = await request(app.getHttpServer())
+        .post('/api/auth/signup')
+        .send({
+          email: buyerEmail,
+          password,
+          displayName: 'Buyer Admin',
+          organizationName: `Buyer Co ${suffix}`,
+          orgType: 'PERSONAL',
+        });
+      const buyer = okData<{
+        user: { id: string };
+        organization: { id: string };
+      }>(buyerRes);
+      buyerOrgId = buyer.organization.id;
+      buyerUserId = buyer.user.id;
+
+      const sellerRes = await request(app.getHttpServer())
+        .post('/api/auth/signup')
+        .send({
+          email: sellerEmail,
+          password,
+          displayName: 'Seller Admin',
+          organizationName: `Seller Co ${suffix}`,
+          orgType: 'PERSONAL',
+        });
+      const seller = okData<{
+        user: { id: string };
+        organization: { id: string };
+      }>(sellerRes);
+      sellerOrgId = seller.organization.id;
+      sellerUserId = seller.user.id;
+
+      expect(buyerOrgId).not.toBe(sellerOrgId);
+    });
+
+    it('02 login: both users receive JWT scoped to their org', async () => {
+      const b = okData<{ tokens: { accessToken: string } }>(
+        await request(app.getHttpServer()).post('/api/auth/login').send({
+          email: buyerEmail,
+          password,
+        }),
+      );
+      buyerToken = b.tokens.accessToken;
+
+      const s = okData<{ tokens: { accessToken: string } }>(
+        await request(app.getHttpServer()).post('/api/auth/login').send({
+          email: sellerEmail,
+          password,
+        }),
+      );
+      sellerToken = s.tokens.accessToken;
+
+      expect(buyerToken).toBeTruthy();
+      expect(sellerToken).toBeTruthy();
+    });
+
+    it('03 seller: create global category (no JWT on categories API)', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/categories')
+        .send({ name: `Flow Cat ${suffix}`, sortOrder: 0, isActive: true });
+      const cat = okData<{ id: number }>(res);
+      categoryId = cat.id;
+    });
+
+    it('04 seller: create product in seller org', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/products')
+        .set('Authorization', `Bearer ${sellerToken}`)
+        .send({
+          categoryId,
+          name: `Flow Snack ${suffix}`,
+          price: 1200,
+          isActive: true,
+        });
+      const p = okData<{ id: number; organizationId: number }>(res);
+      productId = p.id;
+      expect(String(p.organizationId)).toBe(sellerOrgId);
+    });
+
+    it('05 buyer: add seller product to cart (cross-org product id)', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/cart/items')
+        .set('Authorization', `Bearer ${buyerToken}`)
+        .send({ productId, quantity: 2 });
+      const cart = okData<{ items: { productId: number; quantity: number }[] }>(
+        res,
+      );
+      expect(cart.items.some((i) => i.productId === productId)).toBe(true);
+      const line = cart.items.find((i) => i.productId === productId);
+      expect(line?.quantity).toBe(2);
+    });
+
+    it('06 buyer: purchase request from cart creates seller purchase_order', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/purchase-requests')
+        .set('Authorization', `Bearer ${buyerToken}`)
+        .send({ requestMessage: '플로우 테스트 요청' });
+      const pr = okData<{
+        id: number;
+        status: string;
+        items: { sellerOrganizationId: number }[];
+      }>(res);
+      purchaseRequestId = pr.id;
+      expect(pr.status).toBe('OPEN');
+      expect(pr.items.length).toBeGreaterThan(0);
+      expect(String(pr.items[0].sellerOrganizationId)).toBe(sellerOrgId);
+    });
+
+    it('07 buyer: cart empty after purchase request', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/cart')
+        .set('Authorization', `Bearer ${buyerToken}`);
+      const cart = okData<{ items: unknown[] }>(res);
+      expect(cart.items.length).toBe(0);
+    });
+
+    it('08 seller: list purchase orders sees PENDING_SELLER_APPROVAL', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/seller/purchase-orders')
+        .set('Authorization', `Bearer ${sellerToken}`);
+      const list = okData<{
+        data: { id: number; purchaseRequestId: number; status: string }[];
+      }>(res);
+      const row = list.data.find(
+        (o) => o.purchaseRequestId === purchaseRequestId,
+      );
+      expect(row).toBeDefined();
+      expect(row!.status).toBe('PENDING_SELLER_APPROVAL');
+      sellerOrderId = row!.id;
+    });
+
+    it('09 seller: approve → READY_TO_PURCHASE on single-seller request', async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/api/seller/purchase-orders/${sellerOrderId}/approve`)
+        .set('Authorization', `Bearer ${sellerToken}`)
+        .send({ shippingFee: 0 });
+      const order = okData<{ status: string; orderLines: unknown[] }>(res);
+      expect(order.status).toBe('APPROVED');
+      expect(order.orderLines.length).toBeGreaterThan(0);
+
+      const prRes = await request(app.getHttpServer())
+        .get(`/api/purchase-requests/${purchaseRequestId}`)
+        .set('Authorization', `Bearer ${buyerToken}`);
+      const pr = okData<{ status: string }>(prRes);
+      expect(pr.status).toBe('READY_TO_PURCHASE');
+    });
+
+    it('10 seller: record purchase + shipping', async () => {
+      const rec = await request(app.getHttpServer())
+        .post(`/api/seller/purchase-orders/${sellerOrderId}/record-purchase`)
+        .set('Authorization', `Bearer ${sellerToken}`)
+        .send({
+          platform: 'OTHER',
+          note: 'flow e2e',
+        });
+      const purchased = okData<{ status: string }>(rec);
+      expect(purchased.status).toBe('PURCHASED');
+
+      const ship = await request(app.getHttpServer())
+        .patch(`/api/seller/purchase-orders/${sellerOrderId}/shipping`)
+        .set('Authorization', `Bearer ${sellerToken}`)
+        .send({
+          shippingStatus: 'DELIVERED',
+          deliveredAt: new Date().toISOString(),
+        });
+      const after = okData<{ shippingStatus: string }>(ship);
+      expect(after.shippingStatus).toBe('DELIVERED');
+
+      const prRes = await request(app.getHttpServer())
+        .get(`/api/purchase-requests/${purchaseRequestId}`)
+        .set('Authorization', `Bearer ${buyerToken}`);
+      const pr = okData<{ status: string }>(prRes);
+      expect(pr.status).toBe('PURCHASED');
+    });
+
+    it('11 auth/me reflects session user', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/auth/me')
+        .set('Authorization', `Bearer ${buyerToken}`);
+      const me = okData<{
+        user: { id: string };
+        organization: { id: string };
+      }>(res);
+      expect(me.user.id).toBe(buyerUserId);
+      expect(me.organization.id).toBe(buyerOrgId);
+    });
+  },
+);

--- a/snack/test/jest-e2e.json
+++ b/snack/test/jest-e2e.json
@@ -3,6 +3,8 @@
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
+  "testTimeout": 120000,
+  "forceExit": true,
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }


### PR DESCRIPTION
## Overview

판매자 주문 승인·거절·실구매·배송·취소 API를 추가하고, 구매 요청과 주문 상태를 맞춥니다. 초대 시스템에 재전송과 Redis·tokenHash 정합성을 보강했습니다. 카트·구매 요청·상품 API에 JWT 가드를 붙여 토큰 기반 흐름이 끊기지 않게 했고, 전 구간 E2E 플로우 테스트와 판매자 주문 단위 테스트를 추가했습니다.

## Changes

- SellerOrderModule: GET/POST/PATCH /api/seller/purchase-orders (목록, 상세, 승인, 거절, 실구매, 배송, 판매자 취소), 구매 요청 상태 롤업
- PurchaseRequestService.cancel: 같은 요청의 PENDING/APPROVED 주문을 CANCELED로 동기화
- 초대: POST .../resend, Redis invitation:meta:*, tokenHash 검증, 취소 시 Redis 무효화, 재전송 쿨다운(INVITATION_RESEND_COOLDOWN_MINUTES)
- Cart / PurchaseRequest / Products 컨트롤러에 JwtAuthGuard + ApiBearerAuth
- test/flow.e2e-spec.ts, test/create-e2e-app.ts, test/jest-e2e.json (타임아웃·forceExit)
- seller-order.service.spec.ts 단위 테스트
## Why

<!-- 왜 이 변경이 필요한지 -->

## How to Test

1. npm run build
2. npx eslint "src/modules/seller-order/**/*.ts" (또는 npm run lint — 기존 auth 스펙은 의존성 미모킹으로 실패할 수 있음)
3. npx jest seller-order.service.spec
4. MySQL 마이그레이션 후: RUN_FLOW_E2E=1 npm run test:e2e -- flow.e2e-spec.ts
5. Swagger api/docs에서 SellerOrders·Invitations·인증 후 Cart / PurchaseRequest / Products 호출

## Screenshots (optional)

- 해당 없음 (API·테스트 위주)

## Checklist

- [x] build 정상 동작
- [ ] lint 통과  (전체 npm run lint는 기존 auth.*.spec 등 이슈 가능)
- [x] API 테스트 완료 (판매자 주문 단위 테스트 + 선택적 E2E 플로우)
- [ ] breaking change 없음
- [x] Bearer 필수 (이전에 무인증으로 호출하던 클라이언트는 401 가능)

closes #50
closes #51
closes #52